### PR TITLE
moment 模块未引用

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var gitTodos = require('./git-todos'),
+  moment = require('moment'),
   program = require('commander');
 
 


### PR DESCRIPTION
执行

```
git todos after
```

会触发错误。

估计是后期增加新功能改出来的bug，建议增加测试用例。
